### PR TITLE
회의에서 언급된 수정사항 반영

### DIFF
--- a/src/main/java/traveler/travel/domain/account/controller/UserApiController.java
+++ b/src/main/java/traveler/travel/domain/account/controller/UserApiController.java
@@ -2,6 +2,7 @@ package traveler.travel.domain.account.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import traveler.travel.domain.account.Login;
@@ -25,7 +26,6 @@ import java.util.Optional;
 public class UserApiController {
     private final UserService userService;
     private final MailService mailService;
-    private final RedisUtil redisUtil;
     private final SmsService smsService;
 
     private final UserRepository userRepository;
@@ -57,42 +57,38 @@ public class UserApiController {
 
     // 이메일, 전화번호 인증 발송
     @PostMapping("/signup/authcode")
-    public ResponseDto sendAuthCode(@RequestBody EmailAndPhoneAuthDto authDto) throws Exception {
-        if (authDto.getType().equals(EmailAndPhoneAuthDto.Type.EMAIL)) {
-            // 이메일 중복 확인
-            if (userService.checkEmailDuplicate(authDto.getEmail())) {
-                // 이미 가입된 이메일 주소
-                return new ResponseDto<>(null);
-            } else {
-                // 인증 메일 발송
-                String code = mailService.sendAuthMail(authDto.getEmail());
-                return new ResponseDto(null);
-            }
-        } else if (authDto.getType().equals(EmailAndPhoneAuthDto.Type.PHONE)) {
-            // 전화번호 중복 확인
-            if (userService.checkPhoneNumDuplicate(authDto.getPhoneNum())) {
-                return new ResponseDto<>(null);
-            } else {
-                // 인증 문자 발송
-                SmsService.SmsResponseDto response = smsService.sendAuthCode(authDto.getPhoneNum());
-                return new ResponseDto(response);
-            }
+    public ResponseEntity sendAuthCode(@RequestBody EmailAndPhoneAuthDto authDto) throws Exception {
 
+        if (authDto.getEmail() != null) {
+
+            // 인증 메일 발송
+            mailService.sendAuthMail(authDto.getEmail());
+            return new ResponseEntity(HttpStatus.OK);
+
+        } else if (authDto.getPhoneNum() != null) {
+
+            // 인증 문자 발송
+            smsService.sendAuthCode(authDto.getPhoneNum());
+            return new ResponseEntity(HttpStatus.OK);
+
+        } else {
+            return new ResponseEntity(HttpStatus.BAD_REQUEST);
         }
-        return new ResponseDto<>(null);
     }
 
     // 인증
     @PostMapping("/signup/authcode/validate")
-    public ResponseDto<String> validateAuthCode(@RequestBody EmailAndPhoneAuthDto authDto) {
-        String value = authDto.getType().equals(EmailAndPhoneAuthDto.Type.EMAIL)? redisUtil.getValue(authDto.getEmail()) : redisUtil.getValue(authDto.getPhoneNum());
-        if (value == null || !value.equals(authDto.getCode())) {
-            // 유효하지 않은 인증번호
-            return new ResponseDto<String>("invalid code");
+    public ResponseEntity<String> validateAuthCode(@RequestBody EmailAndPhoneAuthDto authDto) {
+
+        String result = userService.checkAuthCode(authDto);
+
+        if (result.equals("200")) {
+            return new ResponseEntity<>(HttpStatus.OK);
+
         } else {
-            // 인증 성공
-            return new ResponseDto<String>("success");
+            return new ResponseEntity<>(result, HttpStatus.BAD_REQUEST);
         }
+
     }
 
     //회원 수정

--- a/src/main/java/traveler/travel/domain/post/controller/CommentApiController.java
+++ b/src/main/java/traveler/travel/domain/post/controller/CommentApiController.java
@@ -2,6 +2,7 @@ package traveler.travel.domain.post.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import traveler.travel.domain.account.Login;
 import traveler.travel.domain.account.entity.User;
@@ -11,7 +12,6 @@ import traveler.travel.domain.post.service.CommentService;
 import traveler.travel.domain.post.service.PostService;
 import traveler.travel.global.dto.CommentRequestDto;
 import traveler.travel.global.dto.CommentResponseDto;
-import traveler.travel.global.dto.ResponseDto;
 
 import java.util.Map;
 
@@ -26,28 +26,28 @@ public class CommentApiController {
 
     // 댓글 작성
     @PostMapping("/")
-    public ResponseDto<CommentResponseDto> addComment(@Login User user, @RequestBody CommentRequestDto commentDto) {
+    public ResponseEntity<CommentResponseDto> addComment(@Login User user, @RequestBody CommentRequestDto commentDto) {
         Post post = postService.findOne(commentDto.getPostId());
         Comment comment = commentService.addComment(commentDto, user, post);
 
-        return new ResponseDto<>(HttpStatus.CREATED.value(), new CommentResponseDto(comment, user));
+        return new ResponseEntity<>(new CommentResponseDto(comment, user), HttpStatus.CREATED);
     }
 
     // 댓글 수정
     @PatchMapping("/{commentId}")
-    public ResponseDto<CommentResponseDto> modifyComment(@Login User user, @RequestBody Map<String, String> commentMap, @PathVariable Long commentId) {
+    public ResponseEntity<CommentResponseDto> modifyComment(@Login User user, @RequestBody Map<String, String> commentMap, @PathVariable Long commentId) {
         String content = commentMap.get("content");
         Comment comment = commentService.modifyComment(commentId, content, user);
 
-        return new ResponseDto<>(HttpStatus.OK.value(), new CommentResponseDto(comment, user));
+        return ResponseEntity.ok(new CommentResponseDto(comment, user));
     }
 
     // 댓글 삭제
     @DeleteMapping("/{commentId}")
-    public ResponseDto<CommentResponseDto> deleteComment(@Login User user, @PathVariable Long commentId) {
+    public ResponseEntity<CommentResponseDto> deleteComment(@Login User user, @PathVariable Long commentId) {
         Comment comment = commentService.deleteComment(commentId, user);
 
-        return new ResponseDto<>(HttpStatus.OK.value(), new CommentResponseDto(comment, user));
+        return ResponseEntity.ok(new CommentResponseDto(comment, user));
     }
 
 }

--- a/src/main/java/traveler/travel/domain/post/controller/PostApiController.java
+++ b/src/main/java/traveler/travel/domain/post/controller/PostApiController.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import traveler.travel.domain.account.Login;
 import traveler.travel.domain.account.entity.User;
@@ -22,46 +23,46 @@ public class PostApiController {
 
     // 게시글 작성
     @PostMapping("/")
-    public ResponseDto<PostDetailDto> createPost(@Login User user
+    public ResponseEntity<PostDetailDto> createPost(@Login User user
             , @RequestBody PostRequestDto postDto) {
         Post post = postService.write(postDto, user);
-        return new ResponseDto<>(HttpStatus.CREATED.value(), new PostDetailDto(post, user));
+        return new ResponseEntity<>(new PostDetailDto(post, user), HttpStatus.CREATED);
     }
 
     // 게시글 단일 조회
     @GetMapping("/{postId}")
-    public ResponseDto<PostDetailDto> findPost(@Login User user, @PathVariable("postId") Long postId) {
+    public ResponseEntity<PostDetailDto> findPost(@Login User user, @PathVariable("postId") Long postId) {
         Post post = postService.view(postId);
-        return new ResponseDto<>(HttpStatus.OK.value(), new PostDetailDto(post, user));
+        return ResponseEntity.ok(new PostDetailDto(post, user));
     }
 
     // 게시글 수정
     @PatchMapping("/{postId}")
-    public ResponseDto<PostDetailDto> modifyPost(@Login User user, @PathVariable("postId") Long postId
+    public ResponseEntity<PostDetailDto> modifyPost(@Login User user, @PathVariable("postId") Long postId
             , @RequestBody PostUpdateDto postDto) {
         Post post = postService.update(postId, postDto, user);
-        return new ResponseDto<>(HttpStatus.OK.value(), new PostDetailDto(post, user));
+        return ResponseEntity.ok(new PostDetailDto(post, user));
     }
 
 
     // 게시글 삭제
     @DeleteMapping("/{postId}")
-    public ResponseDto<PostDetailDto> deletePost(@Login User user, @PathVariable("postId") Long postId) {
+    public ResponseEntity deletePost(@Login User user, @PathVariable("postId") Long postId) {
         Post post = postService.delete(postId, user);
-        return new ResponseDto<>(HttpStatus.OK.value(), new PostDetailDto(post, user));
+        return ResponseEntity.ok().build();
     }
 
     // 게시글 좋아요
     @PostMapping("/{postId}/like")
-    public ResponseDto<PostDetailDto> likeUpdate(@Login User user, @PathVariable("postId") Long postId) {
+    public ResponseEntity<PostDetailDto> likeUpdate(@Login User user, @PathVariable("postId") Long postId) {
         Post post = postService.updateLike(postId, user);
-        return new ResponseDto<>(HttpStatus.OK.value(), new PostDetailDto(post, user));
+        return ResponseEntity.ok(new PostDetailDto(post, user));
     }
 
     // 게시글 조회, 검색
     @GetMapping
-    public Page<PostDetailDto> searchPosts(PostSearchCondition condition, Pageable pageable) {
+    public ResponseEntity<Page<PostDetailDto>> searchPosts(PostSearchCondition condition, Pageable pageable) {
         Page<Post> posts = postService.searchPost(condition, pageable);
-        return posts.map(p -> new PostDetailDto(p, null));
+        return ResponseEntity.ok(posts.map(p -> new PostDetailDto(p, null)));
     }
 }

--- a/src/main/java/traveler/travel/domain/post/controller/PostApiController.java
+++ b/src/main/java/traveler/travel/domain/post/controller/PostApiController.java
@@ -26,14 +26,14 @@ public class PostApiController {
     public ResponseEntity<PostDetailDto> createPost(@Login User user
             , @RequestBody PostRequestDto postDto) {
         Post post = postService.write(postDto, user);
-        return new ResponseEntity<>(new PostDetailDto(post, user), HttpStatus.CREATED);
+        return new ResponseEntity<>(new PostDetailDto(post), HttpStatus.CREATED);
     }
 
     // 게시글 단일 조회
     @GetMapping("/{postId}")
-    public ResponseEntity<PostDetailDto> findPost(@Login User user, @PathVariable("postId") Long postId) {
+    public ResponseEntity<PostDetailDto> findPost(@PathVariable("postId") Long postId) {
         Post post = postService.view(postId);
-        return ResponseEntity.ok(new PostDetailDto(post, user));
+        return ResponseEntity.ok(new PostDetailDto(post));
     }
 
     // 게시글 수정
@@ -41,7 +41,7 @@ public class PostApiController {
     public ResponseEntity<PostDetailDto> modifyPost(@Login User user, @PathVariable("postId") Long postId
             , @RequestBody PostUpdateDto postDto) {
         Post post = postService.update(postId, postDto, user);
-        return ResponseEntity.ok(new PostDetailDto(post, user));
+        return ResponseEntity.ok(new PostDetailDto(post));
     }
 
 
@@ -56,13 +56,13 @@ public class PostApiController {
     @PostMapping("/{postId}/like")
     public ResponseEntity<PostDetailDto> likeUpdate(@Login User user, @PathVariable("postId") Long postId) {
         Post post = postService.updateLike(postId, user);
-        return ResponseEntity.ok(new PostDetailDto(post, user));
+        return ResponseEntity.ok(new PostDetailDto(post));
     }
 
     // 게시글 조회, 검색
     @GetMapping
     public ResponseEntity<Page<PostDetailDto>> searchPosts(PostSearchCondition condition, Pageable pageable) {
         Page<Post> posts = postService.searchPost(condition, pageable);
-        return ResponseEntity.ok(posts.map(p -> new PostDetailDto(p, null)));
+        return ResponseEntity.ok(posts.map(PostDetailDto::new));
     }
 }

--- a/src/main/java/traveler/travel/global/dto/CommentResponseDto.java
+++ b/src/main/java/traveler/travel/global/dto/CommentResponseDto.java
@@ -18,21 +18,17 @@ public class CommentResponseDto {
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
     private LocalDateTime createdAt;
     private boolean isDeleted;
-    private boolean isMine;
 
     private List<CommentResponseDto> children = new ArrayList<>();
-    public CommentResponseDto(Comment comment, User user) {
+    public CommentResponseDto(Comment comment) {
         this.writerId = comment.getWriter().getId();
         this.writerName = comment.getWriter().getNickname();
         this.content = comment.getContent();
         this.createdAt = comment.getCreatedAt();
         this.isDeleted = comment.isDeleted();
 
-        if (user == null) isMine = false;
-        else isMine = writerId.equals(user.getId());
-
         for (Comment child : comment.getChildren()) {
-            this.children.add(new CommentResponseDto(child, user));
+            this.children.add(new CommentResponseDto(child));
         }
     }
 

--- a/src/main/java/traveler/travel/global/dto/EmailAndPhoneAuthDto.java
+++ b/src/main/java/traveler/travel/global/dto/EmailAndPhoneAuthDto.java
@@ -6,10 +6,5 @@ import lombok.Getter;
 public class EmailAndPhoneAuthDto {
     private String phoneNum;
     private String email;
-    private Type type;
     private String code;
-
-    public enum Type{
-        PHONE, EMAIL
-    }
 }

--- a/src/main/java/traveler/travel/global/dto/PostDetailDto.java
+++ b/src/main/java/traveler/travel/global/dto/PostDetailDto.java
@@ -24,13 +24,12 @@ public class PostDetailDto {
     private Long writerId;
     private String writerName;
     private TravelDto travel;
-    private boolean isMine;
 
     private LocalDateTime createdAt;
 
     private List<CommentResponseDto> comments = new ArrayList<>();
 
-    public PostDetailDto(Post post, User user) {
+    public PostDetailDto(Post post) {
         this.postId = post.getId();
         this.title = post.getTitle();
         this.content = post.getContent();
@@ -45,12 +44,9 @@ public class PostDetailDto {
             this.travel = new TravelDto(post.getTravel());
         }
 
-        if (user == null) isMine = false;
-        else isMine = writerId.equals(user.getId());
-
         for (Comment comment : post.getComments()) {
             if (comment.getParent() == null) {
-                this.comments.add(new CommentResponseDto(comment, user));
+                this.comments.add(new CommentResponseDto(comment));
             }
         }
 

--- a/src/main/java/traveler/travel/global/dto/PostDetailDto.java
+++ b/src/main/java/traveler/travel/global/dto/PostDetailDto.java
@@ -59,6 +59,7 @@ public class PostDetailDto {
     @AllArgsConstructor
     @Getter
     static class TravelDto {
+        private Long travelId;
         private TravelType travelType;
         private Gender travelGender;
         private double xPos;
@@ -76,17 +77,18 @@ public class PostDetailDto {
 
 
         public TravelDto(Travel travel) {
-            this.travelType = travel.getTravelType();
-            this.travelGender = travel.getGender();
-            this.xPos = travel.getXPos();
-            this.yPos = travel.getYPos();
-            this.location = travel.getLocation();
-            this.dateTime = travel.getDateTime();
-            this.minAge = travel.getMinAge();
-            this.maxAge = travel.getMaxAge();
-            this.gatherYn = travel.isGatherYn();
-            this.maxCnt = travel.getMaxCnt();
-            this.nowCnt = travel.getNowCnt();
+            travelId = travel.getId();
+            travelType = travel.getTravelType();
+            travelGender = travel.getGender();
+            xPos = travel.getXPos();
+            yPos = travel.getYPos();
+            location = travel.getLocation();
+            dateTime = travel.getDateTime();
+            minAge = travel.getMinAge();
+            maxAge = travel.getMaxAge();
+            gatherYn = travel.isGatherYn();
+            maxCnt = travel.getMaxCnt();
+            nowCnt = travel.getNowCnt();
         }
     }
 

--- a/src/main/java/traveler/travel/global/dto/ResponseDto.java
+++ b/src/main/java/traveler/travel/global/dto/ResponseDto.java
@@ -10,6 +10,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 public class ResponseDto<T> {
-    int status;
     T data;
 }

--- a/src/main/java/traveler/travel/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/traveler/travel/global/exception/GlobalExceptionHandler.java
@@ -7,9 +7,6 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import traveler.travel.global.dto.ResponseDto;
-import traveler.travel.global.exception.EmailDuplicateException;
-import traveler.travel.global.exception.ErrorCode;
-import traveler.travel.global.exception.ErrorResponse;
 
 @ControllerAdvice
 @RestControllerAdvice
@@ -25,17 +22,17 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(BadRequestException.class)
     public ResponseDto handleBadRequestException(BadRequestException e) {
-        return new ResponseDto<>(HttpStatus.BAD_REQUEST.value(), e.getErrorCode());
+        return new ResponseDto<>(e.getErrorCode());
     }
 
     @ExceptionHandler(NotFoundException.class)
     public ResponseDto handleNotFoundException(NotFoundException e) {
-        return new ResponseDto<>(HttpStatus.NOT_FOUND.value(), e.getErrorCode());
+        return new ResponseDto<>(e.getErrorCode());
     }
 
     @ExceptionHandler(ForbiddenException.class)
     public ResponseDto handleForbiddenException(ForbiddenException e) {
-        return new ResponseDto<>(HttpStatus.FORBIDDEN.value(), e.getErrorCode());
+        return new ResponseDto<>(e.getErrorCode());
     }
 
     @ExceptionHandler(value = Exception.class)


### PR DESCRIPTION
회의에서 언급된 수정사항 적용했습니다.

1. 이메일, 전화번호 인증 기능에서 인증코드를 발송할 때 중복체크를 하지 않고, 인증코드를 검증한 뒤 중복체크하는 방식으로 수정했습니다.
2. 인증코드 발송, 검증 api 요청할 때 body에서 type(이메일, 전화번호) 필드를 제거했습니다.
3. api 반환할 때 body 에 http status code 를 넣지 않고 헤더에서 처리하도록 수정했습니다.
4. 게시글, 댓글 dto를 반환할 때 본인이 작성한 것인지 여부를 나타내던 불린 필드를 제거했습니다.